### PR TITLE
fix(utils): correct signed-to-unsigned integer conversion

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>il.co.codeguru</groupId>
     <artifactId>corewars8086</artifactId>
-    <version>5.1.0-SNAPSHOT</version>
+    <version>6.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <url>${project_url}/${project.artifactId}</url>
     <description>Core Wars for standard 8086 assembly</description>

--- a/src/main/java/il/co/codeguru/corewars8086/utils/Unsigned.java
+++ b/src/main/java/il/co/codeguru/corewars8086/utils/Unsigned.java
@@ -2,29 +2,26 @@ package il.co.codeguru.corewars8086.utils;
 
 /**
  * Unsigned numbers utilities.
- * 
+ *
  * @author DL
  */
 public class Unsigned {
-    
+    private Unsigned() {
+    }
+
     public static short unsignedByte(byte num) {
-        return (short)((short)num & 0xFF);
+        return (short) ((short) num & 0xFF);
     }
-    
+
     public static int unsignedShort(short num) {
-        return unsignedShort((int)num);
+        return Short.toUnsignedInt(num);
     }
-    
+
     public static int unsignedShort(int num) {
-        return (num & 0xFFFF);
+        return unsignedShort((short) num);
     }
-    
+
     public static long unsignedInt(int num) {
-        return ((long)num & 0xFFFFFFFF);
+        return Integer.toUnsignedLong(num);
     }
-    
-    /**
-     * Private constructor.
-     */
-    private Unsigned() {}
 }


### PR DESCRIPTION
**BREAKING CHANGE:** `Unsigned.unsignedInt` is no longer broken